### PR TITLE
Simplifying structure for easier maintenance

### DIFF
--- a/index.html
+++ b/index.html
@@ -57,18 +57,6 @@
                     <i class="far fa-angle-down btn-icon" id="btn-icon2"></i>
                 </button>
                 <div class="dropdown-menu hide" aria-labelledby="mainCategorydropdownMenuButton" id="dropdown-menu2">
-                    <a class="dropdown-item" href="javascript:void();"
-                        onclick="handleRoleSelectOption('Salesforce Administrator')">Salesforce Administrator</a>
-                    <a class="dropdown-item" href="javascript:void();"
-                        onclick="handleRoleSelectOption('Salesforce Developer')">Salesforce Developer</a>
-                    <a class="dropdown-item" href="javascript:void();"
-                        onclick="handleRoleSelectOption('Salesforce Architect')">Salesforce Architect</a>
-                    <a class="dropdown-item" href="javascript:void();"
-                        onclick="handleRoleSelectOption('Salesforce Marketer')">Salesforce Marketer</a>
-                    <a class="dropdown-item" href="javascript:void();"
-                        onclick="handleRoleSelectOption('Salesforce Consultant')">Salesforce Consultant</a>
-                    <a class="dropdown-item" href="javascript:void();"
-                        onclick="handleRoleSelectOption('Salesforce Designer')">Salesforce Designer</a>
                 </div>
             </div>
             <div class="dropdown">
@@ -78,78 +66,6 @@
                     <i class="far fa-angle-down btn-icon" id="btn-icon"></i>
                 </button>
                 <div class="dropdown-menu hide" aria-labelledby="dropdownMenuButton" id="dropdown-menu">
-                    <a class="dropdown-item" href="javascript:void();"
-                        onclick="handleSelectOption('B2B Solution Architect')" id="pick">B2B Solution Architect</a>
-                    <a class="dropdown-item" href="javascript:void();"
-                        onclick="handleSelectOption('B2C Solution Architect')" id="pick">B2C Solution Architect</a>
-                    <a class="dropdown-item" href="javascript:void();"
-                        onclick="handleSelectOption('B2C Commerce Architect')" id="pick">B2C Commerce Architect</a>
-                    <a class="dropdown-item" href="javascript:void();"
-                        onclick="handleSelectOption('Administrator')" id="pick">Administrator</a>
-                    <a class="dropdown-item" href="javascript:void();"
-                        onclick="handleSelectOption('Advanced Administrator')" id="pick">Advanced Administrator</a>
-                        <a class="dropdown-item" href="javascript:void();"
-                        onclick="handleSelectOption('Business Analyst')" id="pick">Business Analyst</a>
-                    <a class="dropdown-item" href="javascript:void();"
-                        onclick="handleSelectOption('Platform App Builder')" id="pick">Platform App Builder</a>
-                    <a class="dropdown-item" href="javascript:void();"
-                        onclick="handleSelectOption('CPQ Specialist')" id="pick">CPQ Specialist</a>
-                    <a class="dropdown-item" href="javascript:void();"
-                        onclick="handleSelectOption('Marketing Cloud Administrator')" id="pick">Marketing Cloud Administrator</a>
-                    <a class="dropdown-item" href="javascript:void();"
-                        onclick="handleSelectOption('Platform Developer I')" id="pick">Platform Developer I</a>
-                    <a class="dropdown-item" href="javascript:void();"
-                        onclick="handleSelectOption('Platform Developer II')" id="pick">Platform Developer II</a>
-                    <a class="dropdown-item" href="javascript:void();"
-                        onclick="handleSelectOption('JavaScript Developer I')" id="pick">JavaScript Developer I</a>
-                    <a class="dropdown-item" href="javascript:void();"
-                        onclick="handleSelectOption('Marketing Cloud Email Specialist')" id="pick">Marketing Cloud Email Specialist</a>
-                    <a class="dropdown-item" href="javascript:void();"
-                        onclick="handleSelectOption('Sales Cloud Consultant')" id="pick">Sales Cloud Consultant</a>
-                    <a class="dropdown-item" href="javascript:void();"
-                        onclick="handleSelectOption('Service Cloud Consultant')" id="pick">Service Cloud Consultant</a>
-                    <a class="dropdown-item" href="javascript:void();"
-                        onclick="handleSelectOption('Experience Cloud Consultant')" id="pick">Experience Cloud Consultant</a>
-                    <a class="dropdown-item" href="javascript:void();"
-                        onclick="handleSelectOption('Marketing Cloud Consultant')" id="pick">Marketing Cloud Consultant</a>
-                    <a class="dropdown-item" href="javascript:void();"
-                        onclick="handleSelectOption('Sharing and Visibility Architect')" id="pick">Sharing and Visibility Architect</a>
-                    <a class="dropdown-item" href="javascript:void();"
-                        onclick="handleSelectOption('Data Architect')" id="pick">Data Architect</a>
-                    <a class="dropdown-item" href="javascript:void();"
-                        onclick="handleSelectOption('Identity and Access Management Architect')" id="pick">Identity and Access Management Architect</a>
-                    <a class="dropdown-item" href="javascript:void();"
-                        onclick="handleSelectOption('Integration Architect')" id="pick">Integration Architect</a>
-                    <a class="dropdown-item" href="javascript:void();"
-                        onclick="handleSelectOption('Development Lifecycle and Deployment Architect')" id="pick">Development Lifecycle and Deployment Architect</a>
-                    <a class="dropdown-item" href="javascript:void();"
-                        onclick="handleSelectOption('Heroku Architecture Designer')" id="pick">Heroku Architecture Designer</a>
-                    <a class="dropdown-item" href="javascript:void();"
-                        onclick="handleSelectOption('Marketing Cloud Developer')" id="pick">Marketing Cloud Developer</a>
-                    <a class="dropdown-item" href="javascript:void();"
-                        onclick="handleSelectOption('Pardot Consultant')" id="pick">Pardot Consultant</a>
-                    <a class="dropdown-item" href="javascript:void();"
-                        onclick="handleSelectOption('Pardot Specialist')" id="pick">Pardot Specialist</a>
-                    <a class="dropdown-item" href="javascript:void();"
-                        onclick="handleSelectOption('B2C Commerce Developer')" id="pick">B2C Commerce Developer</a>
-                    <a class="dropdown-item" href="javascript:void();"
-                        onclick="handleSelectOption('Field Service Consultant')" id="pick">Field Service Consultant</a>
-                    <a class="dropdown-item" href="javascript:void();"
-                        onclick="handleSelectOption('Tableau CRM and Einstein Discovery Consultant')" id="pick">Tableau CRM and Einstein Discovery Consultant</a>
-                    <a class="dropdown-item" href="javascript:void();"
-                        onclick="handleSelectOption('Nonprofit Cloud Consultant')" id="pick">Nonprofit Cloud Consultant</a>
-                    <a class="dropdown-item" href="javascript:void();"
-                        onclick="handleSelectOption('Education Cloud Consultant')" id="pick">Education Cloud Consultant</a>
-                    <a class="dropdown-item" href="javascript:void();"
-                        onclick="handleSelectOption('Industries CPQ Developer')" id="pick">Industries CPQ Developer</a>
-                    <a class="dropdown-item" href="javascript:void();"
-                        onclick="handleSelectOption('OmniStudio Developer')" id="pick">OmniStudio Developer</a>
-                    <a class="dropdown-item" href="javascript:void();"
-                        onclick="handleSelectOption('OmniStudio Consultant')" id="pick">OmniStudio Consultant</a>
-                    <a class="dropdown-item" href="javascript:void();"
-                        onclick="handleSelectOption('User Experience Designer')" id="pick">User Experience Designer</a>
-                    <a class="dropdown-item" href="javascript:void();"
-                        onclick="handleSelectOption('Strategy Designer')" id="pick">Strategy Designer</a>
                 </div>
             </div>
             <div class="tool__content">

--- a/resources/js/certification.js
+++ b/resources/js/certification.js
@@ -1,9 +1,10 @@
 class Certification {
-    constructor(name, questionCount, passingScore) {
-        this.categories = [];
+    constructor(name, questionCount, passingScore, roles, categories) {
         this.name = name;
         this.questionCount = questionCount;
         this.passingScore = passingScore;
+        this.roles = roles;
+        this.categories = categories;
     }
 
     getName() {
@@ -12,25 +13,5 @@ class Certification {
 
     getCategories() {
         return this.categories;
-    }
-
-    addCategory(categoryName, categoryWeight) {
-        if (!categoryName || !categoryWeight) return;
-        this.categories.push(this.buildCategory(categoryName, (categoryWeight / 100)));
-    }
-
-    setCategories(categoryNames, categoryWeights) {
-        if (!categoryNames || !categoryWeights) return;
-        if (categoryNames.length !== categoryWeights.length) return;
-        for (let i = 0; i < categoryNames.length; i++) {
-            this.categories.push(this.buildCategory(categoryNames[i], (categoryWeights[i] / 100)));
-        }
-    }
-
-    buildCategory(categoryName, categoryWeight) {
-        return {
-            'name': categoryName,
-            'weight': categoryWeight
-        };
     }
 }

--- a/resources/js/index.js
+++ b/resources/js/index.js
@@ -1,284 +1,389 @@
+const ADMIN = 'Salesforce Administrator', DEVELOPER = 'Salesforce Developer', ARCHITECT = 'Salesforce Architect', MARKETER = 'Salesforce Marketer', CONSULTANT = 'Salesforce Consultant', DESIGNER = 'Salesforce Designer';
+let certificationMap = new Map();
+
 //ADMIN
-let adminCert1 = new Certification('Administrator', 60, 65);
-const adminCert1CategoryNames = ['Configuration and Setup', 'Object Manager and Lightning App Builder', 'Sales and Marketing Applications',
-    'Service and Support Applications', 'Productivity and Collaboration', 'Data and Analytics Management', 'Workflow/Process Automation'
-];
-const adminCert1CategoryWeights = [20, 20, 12, 11, 7, 14, 16];
-adminCert1.setCategories(adminCert1CategoryNames, adminCert1CategoryWeights);
+certificationMap.set('Administrator', new Certification('Administrator', 60, 65, [ADMIN], new Map([
+    ['Configuration and Setup', 20],
+    ['Object Manager and Lightning App Builder', 20],
+    ['Sales and Marketing Applications', 12],
+    ['Service and Support Applications', 11],
+    ['Productivity and Collaboration', 7],
+    ['Data and Analytics Management', 14],
+    ['Workflow/Process Automation', 16]
+])));
 
-let adminCert2 = new Certification('Advanced Administrator', 60, 65);
-const adminCert2CategoryNames = ['Security and Access', 'Objects and Applications', 'Auditing and Monitoring', 'Cloud Applications', 'Data and Analytics Management', 'Environment Management and Deployment', 'Process Automation'];
-const adminCert2CategoryWeights = [20, 19, 10, 11, 13, 7, 20];
-adminCert2.setCategories(adminCert2CategoryNames, adminCert2CategoryWeights);
+certificationMap.set('Advanced Administrator', new Certification('Advanced Administrator', 60, 65, [ADMIN], new Map([
+    ['Security and Access', 20],
+    ['Objects and Applications', 19],
+    ['Auditing and Monitoring', 10],
+    ['Cloud Applications', 11],
+    ['Data and Analytics Management', 13],
+    ['Environment Management and Deployment', 7],
+    ['Process Automation', 20]
+])));
 
-let cPQSpecialist = new Certification('CPQ Specialist', 60, 65);
-const cPQSpecialistCategoryNames = ['CPQ Platform', 'Bundle Configurations', 'Pricing',
-    'Quote Templates', 'Product Selection', 'Orders, Contracts, Amendments, and Renewals', 'Products', 'Approvals'
-];
-const cPQSpecialistCategoryWeights = [23, 17, 16, 7, 7, 15, 11, 4];
-cPQSpecialist.setCategories(cPQSpecialistCategoryNames, cPQSpecialistCategoryWeights);
+certificationMap.set('CPQ Specialist', new Certification('CPQ Specialist', 60, 65, [ADMIN], new Map([
+    ['CPQ Platform', 23],
+    ['Bundle Configurations', 17],
+    ['Pricing', 16],
+    ['Quote Templates', 7],
+    ['Product Selection', 7],
+    ['Orders, Contracts, Amendments, and Renewals', 15],
+    ['Products', 11],
+    ['Approvals', 4]
+])));
 
 //APPBUILDER
-let platformAppBuilderCert = new Certification('Platform App Builder', 60, 63);
-const platformAppBuilderCertCategoryNames = ['Salesforce Fundamentals', 'Data Modeling and Management',
-    'Business Logic and Process Automation', 'User Interface', 'App Development'
-];
-const platformAppBuilderCertCategoryWeights = [23, 22, 28, 17, 10];
-platformAppBuilderCert.setCategories(platformAppBuilderCertCategoryNames, platformAppBuilderCertCategoryWeights);
+certificationMap.set('Platform App Builder', new Certification('Platform App Builder', 60, 63, [ADMIN, DEVELOPER, ARCHITECT], new Map([
+    ['Salesforce Fundamentals', 23],
+    ['Data Modeling and Management', 22],
+    ['Business Logic and Process Automation', 28],
+    ['User Interface', 17],
+    ['App Development', 10]
+])));
 
 //DEVELOPER
-let developerCert1 = new Certification('Platform Developer I', 60, 68);
-const developerCert1CategoryNames = ['Developer Fundamentals', 'Process Automation and Logic', 'User Interface', 'Testing, Debugging, and Deployment'];
-const developerCert1CategoryWeights = [23, 30, 25, 22];
-developerCert1.setCategories(developerCert1CategoryNames, developerCert1CategoryWeights);
+certificationMap.set('Platform Developer I', new Certification('Platform Developer I', 60, 68, [DEVELOPER, ARCHITECT], new Map([
+    ['Developer Fundamentals', 23],
+    ['Process Automation and Logic', 30],
+    ['User Interface', 25],
+    ['Testing, Debugging, and Deployment', 22]
+])));
 
-let developerCert2 = new Certification('Platform Developer II', 60, 70);
-const developerCert2CategoryNames = ['Advanced Developer Fundamentals', 'Process Automation, Logic, and Integration', 'User Interface', 'Testing, Debugging, and Deployment', 'Performance'];
-const developerCert2CategoryWeights = [18, 24, 20, 20, 18];
-developerCert2.setCategories(developerCert2CategoryNames, developerCert2CategoryWeights);
+certificationMap.set('Platform Developer II', new Certification('Platform Developer II', 60, 70, [DEVELOPER], new Map([
+    ['Advanced Developer Fundamentals', 18],
+    ['Process Automation, Logic, and Integration', 24],
+    ['User Interface', 20],
+    ['Testing, Debugging, and Deployment', 20],
+    ['Performance', 18]
+])));
 
-let javaScriptDeveloperI = new Certification('JavaScript Developer I', 60, 65);
-const javaScriptDeveloperICategoryNames = ['Variables, Types, and Collections', 'Objects, Functions, and Classes', 'Browser and Events',
-    'Debugging and Error Handling', 'Asynchronous Programming', 'Server Side JavaScript', 'Testing'
-];
-const javaScriptDeveloperIWeights = [23, 25, 17, 7, 13, 8, 7];
-javaScriptDeveloperI.setCategories(javaScriptDeveloperICategoryNames, javaScriptDeveloperIWeights);
+certificationMap.set('JavaScript Developer I', new Certification('JavaScript Developer I', 60, 65, [DEVELOPER], new Map([
+    ['Variables, Types, and Collections', 23],
+    ['Objects, Functions, and Classes', 25],
+    ['Browser and Events', 17],
+    ['Debugging and Error Handling', 7],
+    ['Asynchronous Programming', 13],
+    ['Server Side JavaScript', 8],
+    ['Testing', 7]
+])));
 
-let b2CCommerceDeveloper = new Certification('B2C Commerce Developer', 60, 65);
-const b2CCommerceDeveloperCategoryNames = ['B2C Commerce Setup', 'Work With a B2C Site', 'Data Management Using Business Manager Usage',
-    'Application Development'
-];
-const b2CCommerceDeveloperCategoryWeights = [11, 12, 24, 53];
-b2CCommerceDeveloper.setCategories(b2CCommerceDeveloperCategoryNames, b2CCommerceDeveloperCategoryWeights);
+certificationMap.set('B2C Commerce Developer', new Certification('B2C Commerce Developer', 60, 65, [DEVELOPER], new Map([
+    ['B2C Commerce Setup', 11],
+    ['Work With a B2C Site', 12],
+    ['Data Management Using Business Manager Usage', 24],
+    ['Application Development', 53]
+])));
 
-let industriesCPQDeveloper = new Certification('Industries CPQ Developer', 60, 63);
-const industriesCPQDeveloperCategoryNames = ['Products', 'Promotions and Discounts', 'Pricing', 'Rules', 'APIs', 'Ordering and Quoting',
-    'Troubleshooting'
-];
-const industriesCPQDeveloperCategoryWeights = [20, 7, 17, 12, 12, 12, 20];
-industriesCPQDeveloper.setCategories(industriesCPQDeveloperCategoryNames, industriesCPQDeveloperCategoryWeights);
+certificationMap.set('Industries CPQ Developer', new Certification('Industries CPQ Developer', 60, 63, [DEVELOPER], new Map([
+    ['Products', 20],
+    ['Promotions and Discounts', 7],
+    ['Pricing', 17],
+    ['Rules', 12],
+    ['APIs', 12],
+    ['Ordering and Quoting', 12],
+    ['Troubleshooting', 20]
+])));
 
-let omniStudioDeveloper = new Certification('OmniStudio Developer', 60, 67);
-const omniStudioDeveloperCategoryNames = ['Flex Cards', 'OmniScripts', 'Integration Procedures', 'Data Raptors', 'Calculation Procedures & Matrices',
-    'Integrated Troubleshooting and Deployment'
-];
-const omniStudioDeveloperCategoryWeights = [15, 20, 17, 20, 8, 20];
-omniStudioDeveloper.setCategories(omniStudioDeveloperCategoryNames, omniStudioDeveloperCategoryWeights);
+certificationMap.set('OmniStudio Developer', new Certification('OmniStudio Developer', 60, 67, [DEVELOPER], new Map([
+    ['Flex Cards', 15],
+    ['OmniScripts', 20],
+    ['Integration Procedures', 17],
+    ['Data Raptors', 20],
+    ['Calculation Procedures & Matrices', 8],
+    ['Integrated Troubleshooting and Deployment', 20]
+])));
 
 //MARKETING
-let marketingEmailSpecialist = new Certification('Marketing Cloud Email Specialist', 60, 67);
-const marketingEmailSpecialistCategoryNames = ['Email Marketing Best Practices', 'Content Creation and Delivery', 'Marketing Automation', 'Subscriber and Data Management', 'Insights and Analytics'];
-const marketingEmailSpecialistCategoryWeights = [10, 24, 26, 26, 14];
-marketingEmailSpecialist.setCategories(marketingEmailSpecialistCategoryNames, marketingEmailSpecialistCategoryWeights);
+certificationMap.set('Marketing Cloud Email Specialist', new Certification('Marketing Cloud Email Specialist', 60, 67, [MARKETER], new Map([
+    ['Email Marketing Best Practices', 10],
+    ['Content Creation and Delivery', 24],
+    ['Marketing Automation', 26],
+    ['Subscriber and Data Management', 26],
+    ['Insights and Analytics', 14]
+])));
 
-let marketingCloudAdministrator = new Certification('Marketing Cloud Administrator', 60, 67);
-const marketingCloudAdministratorCategoryNames = ['Digital Marketing Proficiency', 'Subscriber Data Management', 'Setup',
-    'Channel Management', 'Maintenance'
-];
-const marketingCloudAdministratorCategoryWeights = [13, 18, 38, 16, 15];
-marketingCloudAdministrator.setCategories(marketingCloudAdministratorCategoryNames, marketingCloudAdministratorCategoryWeights);
+certificationMap.set('Marketing Cloud Administrator', new Certification('Marketing Cloud Administrator', 60, 67, [ADMIN, MARKETER], new Map([
+    ['Digital Marketing Proficiency', 13],
+    ['Subscriber Data Management', 18],
+    ['Setup', 38],
+    ['Channel Management', 16],
+    ['Maintenance', 15]
+])));
 
-let marketingCloudDeveloper = new Certification('Marketing Cloud Developer', 60, 63);
-const marketingCloudDeveloperCategoryNames = ['Data Modeling', 'Programmatic Languages', 'API',
-    'Data Management', 'Security'
-];
-const marketingCloudDeveloperCategoryWeights = [14, 35, 22, 22, 7];
-marketingCloudDeveloper.setCategories(marketingCloudDeveloperCategoryNames, marketingCloudDeveloperCategoryWeights);
+certificationMap.set('Marketing Cloud Developer', new Certification('Marketing Cloud Developer', 60, 63, [DEVELOPER, MARKETER], new Map([
+    ['Data Modeling', 14],
+    ['Programmatic Languages', 35],
+    ['API', 22],
+    ['Data Management', 22],
+    ['Security', 7]
+])));
 
-let pardotSpecialist = new Certification('Pardot Specialist', 60, 72);
-const pardotSpecialistCategoryNames = ['Visitors and Prospects', 'Administration', 'Pardot Forms, Form Handlers and Landing Pages',
-    'Lead Management', 'Email Marketing', 'Engagement Studio'
-];
-const pardotSpecialistCategoryWeights = [8, 11, 20, 24, 20, 17];
-pardotSpecialist.setCategories(pardotSpecialistCategoryNames, pardotSpecialistCategoryWeights);
+certificationMap.set('Pardot Specialist', new Certification('Pardot Specialist', 60, 72, [MARKETER], new Map([
+    ['Visitors and Prospects', 8],
+    ['Administration', 11],
+    ['Pardot Forms, Form Handlers and Landing Pages', 20],
+    ['Lead Management', 24],
+    ['Email Marketing', 20],
+    ['Engagement Studio', 17]
+])));
 
-//CONSULTANT
-let businessAnalyst = new Certification('Business Analyst', 60, 62);
-const businessAnalystCategoryNames = ['Customer Discovery', 'Collaboration with Stakeholders', 'Business Process Mapping', 'Requirements', 'User Stories', 'User Acceptance'];
-const businessAnalystCategoryWeights = [17, 24, 16, 17, 18, 8];
-businessAnalyst.setCategories(businessAnalystCategoryNames, businessAnalystCategoryWeights);
+// //CONSULTANT
+certificationMap.set('Business Analyst', new Certification('Business Analyst', 60, 62, [ADMIN, CONSULTANT], new Map([
+    ['Customer Discovery', 17],
+    ['Collaboration with Stakeholders', 24],
+    ['Business Process Mapping', 16],
+    ['Requirements', 17],
+    ['User Stories', 18],
+    ['User Acceptance', 8]
+])));
 
-let communityCloudConsCert = new Certification('Experience Cloud Consultant', 60, 65);
-const communityCloudConsCertCategoryNames = ['Experience Cloud Basics', 'Sharing, Visibility, and Licensing', 'Branding, Personalization, and Content', 'Templates and Themes', 'User Creation and Authentication', 'Adoption and Analytics', 'Administration, Setup and Configuration', 'Customization Considerations, and Limitations'];
-const communityCloudConsCertCategoryWeights = [8, 17, 15, 10, 13, 5, 25, 7];
-communityCloudConsCert.setCategories(communityCloudConsCertCategoryNames, communityCloudConsCertCategoryWeights);
+certificationMap.set('Experience Cloud Consultant', new Certification('Experience Cloud Consultant', 60, 65, [CONSULTANT], new Map([
+    ['Experience Cloud Basics', 8],
+    ['Sharing, Visibility, and Licensing', 17],
+    ['Branding, Personalization, and Content', 15],
+    ['Templates and Themes', 10],
+    ['User Creation and Authentication', 13],
+    ['Adoption and Analytics', 5],
+    ['Administration, Setup and Configuration', 25],
+    ['Customization Considerations, and Limitations', 7]
+])));
 
-let marketingCloudConsCert = new Certification('Marketing Cloud Consultant', 60, 67);
-const marketingCloudConsCertCategoryNames = ['Discovery and Architecture', 'Integration', 'Account Configuration', 'Automation', 'Data Modeling and Management', 'Messaging'];
-const marketingCloudConsCertCategoryWeights = [16, 20, 12, 20, 21, 11];
-marketingCloudConsCert.setCategories(marketingCloudConsCertCategoryNames, marketingCloudConsCertCategoryWeights);
+certificationMap.set('Marketing Cloud Consultant', new Certification('Marketing Cloud Consultant', 60, 67, [MARKETER, CONSULTANT], new Map([
+    ['Discovery and Architecture', 16],
+    ['Integration', 20],
+    ['Account Configuration', 12],
+    ['Automation', 20],
+    ['Data Modeling and Management', 21],
+    ['Messaging', 11]
+])));
 
-let salesCloudConsCert = new Certification('Sales Cloud Consultant', 60, 68);
-const salesCloudConsCertCategoryNames = ['Sales Practices', 'Implementation Strategies', 'Application of Product Knowledge', 'Lead Management',
-    'Account and Contact Management', 'Opportunity Management', 'Sales Productivity and Integration', 'Consulting Practices', 'Sales Metrics, Reports & Dashboards', 'Data Management'
-];
-const salesCloudConsCertCategoryWeights = [11, 13, 18, 7, 11, 10, 8, 7, 7, 8];
-salesCloudConsCert.setCategories(salesCloudConsCertCategoryNames, salesCloudConsCertCategoryWeights);
+certificationMap.set('Sales Cloud Consultant', new Certification('Sales Cloud Consultant', 60, 68, [CONSULTANT], new Map([
+    ['Sales Practices', 11],
+    ['Implementation Strategies', 13],
+    ['Application of Product Knowledge', 18],
+    ['Lead Management', 7],
+    ['Account and Contact Management', 11],
+    ['Opportunity Management', 10],
+    ['Sales Productivity and Integration', 8],
+    ['Consulting Practices', 7],
+    ['Sales Metrics, Reports & Dashboards', 7],
+    ['Data Management', 8]
+])));
 
-let serviceCloudConsCert = new Certification('Service Cloud Consultant', 60, 67);
-const serviceCloudConsCertCategoryNames = ['Industry Knowledge', 'Implementation Strategies', 'Service Cloud Solution Design', 'Knowledge Management',
-    'Interaction Channels', 'Case Management', 'Contact Center Analytics', 'Integration and Data Management', 'Service Console'
-];
-const serviceCloudConsCertCategoryWeights = [10, 15, 16, 9, 10, 15, 5, 5, 15];
-serviceCloudConsCert.setCategories(serviceCloudConsCertCategoryNames, serviceCloudConsCertCategoryWeights);
+certificationMap.set('Service Cloud Consultant', new Certification('Service Cloud Consultant', 60, 67, [CONSULTANT], new Map([
+    ['Industry Knowledge', 10],
+    ['Implementation Strategies', 15],
+    ['Service Cloud Solution Design', 16],
+    ['Knowledge Management', 9],
+    ['Interaction Channels', 10],
+    ['Case Management', 15],
+    ['Contact Center Analytics', 5],
+    ['Integration and Data Management', 5],
+    ['Service Console', 15]
+])));
 
-let pardotConsultant = new Certification('Pardot Consultant', 60, 68);
-const pardotConsultantCategoryNames = ['Evaluation', 'Account Configuration', 'Automating Business Processes', 'Email Marketing', 'Lead Management', 'Personalizing the Prospect Experience', 'Reporting, Metrics & Analytics', 'Salesforce Engage'];
-const pardotConsultantCategoryWeights = [17, 20, 17, 10, 14, 8, 11, 3];
-pardotConsultant.setCategories(pardotConsultantCategoryNames, pardotConsultantCategoryWeights);
+certificationMap.set('Pardot Consultant', new Certification('Pardot Consultant', 60, 68, [MARKETER, CONSULTANT], new Map([
+    ['Evaluation', 17],
+    ['Account Configuration', 20],
+    ['Automating Business Processes', 17],
+    ['Email Marketing', 10],
+    ['Lead Management', 14],
+    ['Personalizing the Prospect Experience', 8],
+    ['Reporting, Metrics & Analytics', 11],
+    ['Salesforce Engage', 3]
+])));
 
-let fieldServiceLightningConsultant = new Certification('Field Service Consultant', 60, 63);
-const fieldServiceLightningConsultantCategoryNames = ['Managing Resources', 'Managing Work Orders', 'Managing Scheduling and Optimization', 'Configuring Mobility',
-    'Managing Inventory', 'Managing Assets', 'Configuring Maintenance Plans', 'Permissions and Sharing'
-];
-const fieldServiceLightningConsultantCategoryWeights = [16, 23, 28, 10, 8, 5, 5, 5];
-fieldServiceLightningConsultant.setCategories(fieldServiceLightningConsultantCategoryNames, fieldServiceLightningConsultantCategoryWeights);
+certificationMap.set('Field Service Consultant', new Certification('Field Service Consultant', 60, 63, [CONSULTANT], new Map([
+    ['Managing Resources', 16],
+    ['Managing Work Orders', 23],
+    ['Managing Scheduling and Optimization', 28],
+    ['Configuring Mobility', 10],
+    ['Managing Inventory', 8],
+    ['Managing Assets', 5],
+    ['Configuring Maintenance Plans', 5],
+    ['Permissions and Sharing', 5]
+])));
 
-let einsteinAnalyticsConsultant = new Certification('Tableau CRM and Einstein Discovery Consultant', 60, 68);
-const einsteinAnalyticsConsultantCategoryNames = ['Data Layer', 'Security', 'Administration', 'Tableau CRM Dashboard Design',
-    'Tableau CRM Dashboard Implementation', 'Einstein Discovery Story Design'
-];
-const einsteinAnalyticsConsultantCategoryWeights = [24, 11, 9, 19, 18, 19];
-einsteinAnalyticsConsultant.setCategories(einsteinAnalyticsConsultantCategoryNames, einsteinAnalyticsConsultantCategoryWeights);
+certificationMap.set('Tableau CRM and Einstein Discovery Consultant', new Certification('Tableau CRM and Einstein Discovery Consultant', 60, 68, [CONSULTANT], new Map([
+    ['Data Layer', 24],
+    ['Security', 11],
+    ['Administration', 9],
+    ['Tableau CRM Dashboard Design', 19],
+    ['Tableau CRM Dashboard Implementation', 18],
+    ['Einstein Discovery Story Design', 19]
+])));
 
-let nonprofitCloudConsultant = new Certification('Nonprofit Cloud Consultant', 60, 67);
-const nonprofitCloudConsultantCategoryNames = ['Domain Expertise', 'Nonprofit Cloud Product Configuration', 'Implementation Strategies and Best Practices', 'Solution Design', 
-    'Integration and Data Management', 'Analytics'
-];
-const nonprofitCloudConsultantCategoryWeights = [20, 22, 18, 20, 15, 5];
-nonprofitCloudConsultant.setCategories(nonprofitCloudConsultantCategoryNames, nonprofitCloudConsultantCategoryWeights);
+certificationMap.set('Nonprofit Cloud Consultant', new Certification('Nonprofit Cloud Consultant', 60, 67, [CONSULTANT], new Map([
+    ['Domain Expertise', 20],
+    ['Nonprofit Cloud Product Configuration', 22],
+    ['Implementation Strategies and Best Practices', 18],
+    ['Solution Design', 20],
+    ['Integration and Data Management', 15],
+    ['Analytics', 5]
+])));
 
-let educationCloudConsultant = new Certification('Education Cloud Consultant', 60, 67);
-const educationCloudConsultantCategoryNames = ['Domain Expertise', 'Education Cloud Configuration', 'Implementation Strategies and Best Practices', 'Solution Design', 'Integration and Data Management', 'Analytics'];
-const educationCloudConsultantCategoryWeights = [18, 22, 18, 19, 16, 7];
-educationCloudConsultant.setCategories(educationCloudConsultantCategoryNames, educationCloudConsultantCategoryWeights);
+certificationMap.set('Education Cloud Consultant', new Certification('Education Cloud Consultant', 60, 67, [CONSULTANT], new Map([
+    ['Domain Expertise', 18],
+    ['Education Cloud Configuration', 22],
+    ['Implementation Strategies and Best Practices', 18],
+    ['Solution Design', 19],
+    ['Integration and Data Management', 16],
+    ['Analytics', 7]
+])));
 
-let omniStudioConsultant = new Certification('OmniStudio Consultant', 60, 63);
-const omniStudioConsultantCategoryNames = ['FlexCards', 'OmniScripts', 'Data Tools', 'Best Fit Solutioning'];
-const omniStudioConsultantCategoryWeights = [23, 27, 23, 27];
-omniStudioConsultant.setCategories(omniStudioConsultantCategoryNames, omniStudioConsultantCategoryWeights);
+certificationMap.set('OmniStudio Consultant', new Certification('OmniStudio Consultant', 60, 63, [CONSULTANT], new Map([
+    ['FlexCards', 23],
+    ['OmniScripts', 27],
+    ['Data Tools', 23],
+    ['Best Fit Solutioning', 27]
+])));
 
-//ARCHITECTURE
-let sharingAndVisibilityDesigner = new Certification('Sharing and Visibility Architect', 60, 67);
-const sharingAndVisibilityCategoryNames = ['Declarative Sharing', 'Performance and Scalability', 'Programmatic Sharing'];
-const sharingAndVisibilityCategoryWeights = [76, 7, 17];
-sharingAndVisibilityDesigner.setCategories(sharingAndVisibilityCategoryNames, sharingAndVisibilityCategoryWeights);
+// //ARCHITECTURE
+certificationMap.set('Sharing and Visibility Architect', new Certification('Sharing and Visibility Architect', 60, 67, [ARCHITECT], new Map([
+    ['Declarative Sharing', 76],
+    ['Performance and Scalability', 7],
+    ['Programmatic Sharing', 17]
+])));
 
-let identityAndAccessMgmtCert = new Certification('Identity and Access Management Architect', 60, 67);
-const identityCertCategoryNames = ['Identity Management Concepts', 'Accepting Third-Party Identity in Salesforce', 'Salesforce as an Identity Provider',
-    'Access Management Best Practices', 'Salesforce Identity', 'Community (Partner and Customer)'
-];
-const identityCertCategoryWeights = [17, 21, 17, 15, 12, 18];
-identityAndAccessMgmtCert.setCategories(identityCertCategoryNames, identityCertCategoryWeights);
+certificationMap.set('Identity and Access Management Architect', new Certification('Identity and Access Management Architect', 60, 67, [ARCHITECT], new Map([
+    ['Identity Management Concepts', 17],
+    ['Accepting Third-Party Identity in Salesforce', 21],
+    ['Salesforce as an Identity Provider', 17],
+    ['Access Management Best Practices', 15],
+    ['Salesforce Identity', 12],
+    ['Community (Partner and Customer)', 18]
+])));
 
-let dataArchitectureAndManagementDesignerCert = new Certification('Data Architect', 60, 58);
-const dataArchitectureAndManagementDesignerCategoryNames = ['Data Modeling/Database Design', 'Master Data Management', 'Salesforce Data Management',
-    'Data Governance', 'Large Data Volume Considerations', 'Data Migration'
-];
-const dataArchitectureAndManagementDesignerCategoryWeights = [25, 5, 25, 10, 20, 15];
-dataArchitectureAndManagementDesignerCert.setCategories(dataArchitectureAndManagementDesignerCategoryNames, dataArchitectureAndManagementDesignerCategoryWeights);
+certificationMap.set('Data Architect', new Certification('Data Architect', 60, 58, [ARCHITECT], new Map([
+    ['Data Modeling/Database Design', 25],
+    ['Master Data Management', 5],
+    ['Salesforce Data Management', 25],
+    ['Data Governance', 10],
+    ['Large Data Volume Considerations', 20],
+    ['Data Migration', 15]
+])));
 
-let integrationArchitectureDesignerCert = new Certification('Integration Architect', 60, 67);
-const integrationArchitectureDesignerCategoryNames = ['Evaluate the Current System Landscape', 'Evaluate Business Needs', 'Translate Needs to Integration Requirements', 'Design Integration Solutions',
-    'Build Solution', 'Maintain Integration'
-];
-const integrationArchitectureDesignerCategoryWeights = [8, 11, 22, 28, 23, 8];
-integrationArchitectureDesignerCert.setCategories(integrationArchitectureDesignerCategoryNames, integrationArchitectureDesignerCategoryWeights);
+certificationMap.set('Integration Architect', new Certification('Integration Architect', 60, 67, [ARCHITECT], new Map([
+    ['Evaluate the Current System Landscape', 8],
+    ['Evaluate Business Needs', 11],
+    ['Translate Needs to Integration Requirements', 22],
+    ['Design Integration Solutions', 28],
+    ['Build Solution', 23],
+    ['Maintain Integration', 8]
+])));
 
-let developmentLifecycleandDeploymentDesigner = new Certification('Development Lifecycle and Deployment Architect', 60, 65);
-const developmentLifecycleandDeploymentDesignerCategoryNames = ['Application Lifecycle Management', 'Planning', 'System Design', 'Building', 'Deploying', 'Testing',
-'Releasing', 'Operating'];
-const developmentLifecycleandDeploymentDesignerCategoryWeights = [8, 13, 15, 14, 14, 13, 13, 10];
-developmentLifecycleandDeploymentDesigner.setCategories(developmentLifecycleandDeploymentDesignerCategoryNames, developmentLifecycleandDeploymentDesignerCategoryWeights);
+certificationMap.set('Development Lifecycle and Deployment Architect', new Certification('Development Lifecycle and Deployment Architect', 60, 65, [ARCHITECT], new Map([
+    ['Application Lifecycle Management', 8],
+    ['Planning', 13],
+    ['System Design', 15],
+    ['Building', 14],
+    ['Deploying', 14],
+    ['Testing', 13],
+    ['Releasing', 13],
+    ['Operating', 10]
+])));
 
-let herokuArchitectureDesigner = new Certification('Heroku Architecture Designer', 60, 72);
-const herokuArchitectureDesignerCategoryNames = ['Heroku Platform', 'Data', 'Security', 'Heroku Enterprise',
-    'Architect Applications', 'Integrations'
-];
-const herokuArchitectureDesignerCategoryWeights = [10, 17, 15, 28, 15, 15];
-herokuArchitectureDesigner.setCategories(herokuArchitectureDesignerCategoryNames, herokuArchitectureDesignerCategoryWeights);
+certificationMap.set('Heroku Architecture Designer', new Certification('Heroku Architecture Designer', 60, 72, [ARCHITECT], new Map([
+    ['Heroku Platform', 10],
+    ['Data', 17],
+    ['Security', 15],
+    ['Heroku Enterprise', 28],
+    ['Architect Applications', 15],
+    ['Integrations', 15]
+])));
 
-let b2CSolutionArchitect = new Certification('B2C Solution Architect', 60, 63);
-const b2CSolutionArchitectCategoryNames = ['Discovery and Customer Success', 'Functional Capabilities and Business Value', 'Architecture Design', 'Data Models and Management',
-    'Integration'
-];
-const b2CSolutionArchitectCategoryWeights = [18, 19, 23, 21, 19];
-b2CSolutionArchitect.setCategories(b2CSolutionArchitectCategoryNames, b2CSolutionArchitectCategoryWeights);
+certificationMap.set('B2C Solution Architect', new Certification('B2C Solution Architect', 60, 63, [ARCHITECT], new Map([
+    ['Discovery and Customer Success', 18],
+    ['Functional Capabilities and Business Value', 19],
+    ['Architecture Design', 23],
+    ['Data Models and Management', 21],
+    ['Integration', 19]
+])));
 
-let b2BSolutionArchitect = new Certification('B2B Solution Architect', 60, 58);
-const b2BSolutionArchitectCategoryNames = ['Discovery and Customer Success', 'Data Governance and Integration', 'Design', 'Delivery', 'Operationalize the Solution'
-];
-const b2BSolutionArchitectCategoryWeights = [25, 26, 29, 12, 8];
-b2BSolutionArchitect.setCategories(b2BSolutionArchitectCategoryNames, b2BSolutionArchitectCategoryWeights);
+certificationMap.set('B2B Solution Architect', new Certification('B2B Solution Architect', 60, 58, [ARCHITECT], new Map([
+    ['Discovery and Customer Success', 25],
+    ['Data Governance and Integration', 26],
+    ['Design', 29],
+    ['Delivery', 12],
+    ['Operationalize the Solution', 8]
+])));
 
-let b2CCommerceArchitect = new Certification('B2C Commerce Architect', 60, 65);
-const b2CCommerceArchitectCategoryNames = ['Design/Discovery', 'Build', 'Monitoring/Troubleshooting', 'Integrations and Customizations', 'Launch'];
-const b2CCommerceArchitectCategoryWeights = [29, 19, 14, 22, 16];
-b2CCommerceArchitect.setCategories(b2CCommerceArchitectCategoryNames, b2CCommerceArchitectCategoryWeights);
+certificationMap.set('B2C Commerce Architect', new Certification('B2C Commerce Architect', 60, 65, [ARCHITECT], new Map([
+    ['Design/Discovery', 29],
+    ['Build', 19],
+    ['Monitoring/Troubleshooting', 14],
+    ['Integrations and Customizations', 22],
+    ['Launch', 16]
+])));
 
-// Salesforce Designer Certs
-let userExperienceDesigner = new Certification('User Experience Designer', 60, 65);
-const userExperienceDesignerCategoryNames = ['Discovery', 'UX Fundamentals', 'Human-Centered Design', 'Declarative Design', 'Testing', 'Salesforce Lightning Design System (SLDS)'];
-const userExperienceDesignerCategoryWeights = [13, 16, 12, 27, 11, 21];
-userExperienceDesigner.setCategories(userExperienceDesignerCategoryNames, userExperienceDesignerCategoryWeights);
+// // Salesforce Designer Certs
+certificationMap.set('User Experience Designer', new Certification('User Experience Designer', 60, 65, [DESIGNER], new Map([
+    ['Discovery', 13],
+    ['UX Fundamentals', 16],
+    ['Human-Centered Design', 12],
+    ['Declarative Design', 27],
+    ['Testing', 11],
+    ['Salesforce Lightning Design System (SLDS)', 21]
+])));
 
-let strategyDesigner = new Certification('Strategy Designer', 60, 70);
-const strategyDesignerCategoryNames = ['Value Design', 'Tools and Artifacts', 'Intangible Deliverables', 'Leveraging Adjacent Roles/Skills'];
-const strategyDesignerCategoryWeights = [32, 23, 26, 19];
-strategyDesigner.setCategories(strategyDesignerCategoryNames, strategyDesignerCategoryWeights);
+certificationMap.set('Strategy Designer', new Certification('Strategy Designer', 60, 70, [DESIGNER], new Map([
+    ['Value Design', 32],
+    ['Tools and Artifacts', 23],
+    ['Intangible Deliverables', 26],
+    ['Leveraging Adjacent Roles/Skills', 19]
+])));
 
-const certificationMap = new Map();
-certificationMap.set(adminCert1.getName(), adminCert1);
-certificationMap.set(adminCert2.getName(), adminCert2);
-certificationMap.set(platformAppBuilderCert.getName(), platformAppBuilderCert);
-certificationMap.set(cPQSpecialist.getName(), cPQSpecialist);
-certificationMap.set(developerCert1.getName(), developerCert1);
-certificationMap.set(javaScriptDeveloperI.getName(), javaScriptDeveloperI);
-certificationMap.set(developerCert2.getName(), developerCert2);
-certificationMap.set(marketingEmailSpecialist.getName(), marketingEmailSpecialist);
-certificationMap.set(marketingCloudAdministrator.getName(), marketingCloudAdministrator);
-certificationMap.set(marketingCloudDeveloper.getName(), marketingCloudDeveloper);
-certificationMap.set(communityCloudConsCert.getName(), communityCloudConsCert);
-certificationMap.set(marketingCloudConsCert.getName(), marketingCloudConsCert);
-certificationMap.set(salesCloudConsCert.getName(), salesCloudConsCert);
-certificationMap.set(serviceCloudConsCert.getName(), serviceCloudConsCert);
-certificationMap.set(identityAndAccessMgmtCert.getName(), identityAndAccessMgmtCert);
-certificationMap.set(sharingAndVisibilityDesigner.getName(), sharingAndVisibilityDesigner);
-certificationMap.set(dataArchitectureAndManagementDesignerCert.getName(), dataArchitectureAndManagementDesignerCert);
-certificationMap.set(integrationArchitectureDesignerCert.getName(), integrationArchitectureDesignerCert);
-certificationMap.set(developmentLifecycleandDeploymentDesigner.getName(), developmentLifecycleandDeploymentDesigner);
-certificationMap.set(herokuArchitectureDesigner.getName(), herokuArchitectureDesigner);
-certificationMap.set(b2CCommerceDeveloper.getName(), b2CCommerceDeveloper);
-certificationMap.set(b2CSolutionArchitect.getName(), b2CSolutionArchitect);
-certificationMap.set(b2BSolutionArchitect.getName(), b2BSolutionArchitect);
-certificationMap.set(b2CCommerceArchitect.getName(), b2CCommerceArchitect);
-certificationMap.set(pardotConsultant.getName(), pardotConsultant);
-certificationMap.set(pardotSpecialist.getName(), pardotSpecialist);
-certificationMap.set(fieldServiceLightningConsultant.getName(), fieldServiceLightningConsultant);
-certificationMap.set(einsteinAnalyticsConsultant.getName(), einsteinAnalyticsConsultant);
-certificationMap.set(nonprofitCloudConsultant.getName(), nonprofitCloudConsultant);
-certificationMap.set(educationCloudConsultant.getName(), educationCloudConsultant);
-certificationMap.set(industriesCPQDeveloper.getName(), industriesCPQDeveloper);
-certificationMap.set(omniStudioDeveloper.getName(), omniStudioDeveloper);
-certificationMap.set(omniStudioConsultant.getName(), omniStudioConsultant);
-certificationMap.set(userExperienceDesigner.getName(), userExperienceDesigner);
-certificationMap.set(businessAnalyst.getName(), businessAnalyst);
-certificationMap.set(strategyDesigner.getName(), strategyDesigner);
+// Sort all the Certifications alphabetically
+certificationMap = new Map([...certificationMap].sort());
 
 // Here we map certifications to one or more Roles that can be filtered on
-const RoleMap = new Map();
-RoleMap.set('Salesforce Administrator', [adminCert1, adminCert2, businessAnalyst, platformAppBuilderCert, cPQSpecialist, marketingCloudAdministrator]);
-RoleMap.set('Salesforce Developer', [platformAppBuilderCert, developerCert1, developerCert2, javaScriptDeveloperI, marketingCloudDeveloper, b2CCommerceDeveloper, industriesCPQDeveloper, omniStudioDeveloper]);
-RoleMap.set('Salesforce Architect', [b2BSolutionArchitect, b2CSolutionArchitect, b2CCommerceArchitect, platformAppBuilderCert, developerCert1, sharingAndVisibilityDesigner, identityAndAccessMgmtCert, dataArchitectureAndManagementDesignerCert, 
-    integrationArchitectureDesignerCert,developmentLifecycleandDeploymentDesigner, herokuArchitectureDesigner]);
-RoleMap.set('Salesforce Marketer', [marketingCloudAdministrator, marketingEmailSpecialist, marketingCloudConsCert, marketingCloudDeveloper, pardotConsultant, pardotSpecialist]);
-RoleMap.set('Salesforce Consultant', [businessAnalyst, salesCloudConsCert, serviceCloudConsCert, communityCloudConsCert, marketingCloudConsCert, pardotConsultant, fieldServiceLightningConsultant,
-    einsteinAnalyticsConsultant, nonprofitCloudConsultant, educationCloudConsultant, omniStudioConsultant]);
-RoleMap.set('Salesforce Designer', [userExperienceDesigner, strategyDesigner]);
+let RoleMap = new Map();
+for (const cert of certificationMap.values()) {
+    for (const role of cert.roles) {
+        if (RoleMap.has(role)) {
+            let tempRoleArray = RoleMap.get(role);
+            tempRoleArray.push(cert);
+            RoleMap.set(role, tempRoleArray);
+        } else {
+            RoleMap.set(role, [cert]);
+        }
+    }
+}
 
-let selectedCertification = adminCert1;
+// Verifying that the categories for each certification sum up to 100
+for (const cert of certificationMap.values()) {
+    let sumOfCategories = 0;
+    for (const category of cert.categories.values()) {
+        sumOfCategories += category;
+    }
+    if (sumOfCategories !== 100) {
+        console.error(`Certification ${cert.name}'s categories sum up to ${sumOfCategories}. You should check that..`);
+    }
+}
+
+// Sort all the Roles alphabetically
+RoleMap = new Map([...RoleMap].sort());
+
+// Set default certification
+let selectedCertification = certificationMap.get('Administrator');
 
 window.addEventListener('load', function () {
+    // Auto-populate the Roles on the canvas
+    let rolePicklist = document.getElementById('dropdown-menu2');
+    rolePicklist.innerHTML = '';
+    for (const role of RoleMap.keys()) {
+        rolePicklist.insertAdjacentHTML('beforeend', `<a class="dropdown-item" href="javascript:void();" onclick="handleRoleSelectOption('${role}')">${role}</a>`);
+    }
+
+    // Auto-populate the Certifications on the canvas
+    let certPicklist = document.getElementById('dropdown-menu');
+    certPicklist.innerHTML = '';
+    for (const cert of certificationMap.keys()) {
+        certPicklist.insertAdjacentHTML('beforeend', `<a class="dropdown-item" href="javascript:void();" onclick="handleSelectOption('${cert}')" id="pick">${cert}</a>`);
+    }
+
+    // Load default certification
     handleSelectOption('Administrator');
     hideShowDropdownMenu();
 })
@@ -346,59 +451,51 @@ function handleRoleSelectOption(mainCategory) {
 }
 
 function showRelevantCertifications(mainCategory) {
-    var divs = document.querySelectorAll('*[id^="pick"]');
-    let certs = RoleMap.get(mainCategory);
     let certsText = [];
-    for (let i = 0; i < certs.length; i++) {
-        certsText[i] = certs[i].name;
+    for (const cert of RoleMap.get(mainCategory)) {
+        certsText.push(cert.name);
     }
-    for (var i = 0; i < divs.length; i++) {
-        if (certsText.includes(divs[i].textContent)) {
-            divs[i].classList.remove('hide');
+    let picks = document.querySelectorAll('*[id^="pick"]');
+    for (const pick of picks) {
+        if (certsText.includes(pick.textContent)) {
+            pick.classList.remove('hide');
         } else {
-            divs[i].classList.add('hide');
+            pick.classList.add('hide');
         }
     }
 }
 
 function changeDropdownMenuText(certificationName) {
     if (!certificationName) return;
-    let dropdownMenuButton__text = document.getElementById('dropdownMenuButton__text');
-    dropdownMenuButton__text.innerHTML = certificationName;
+    document.getElementById('dropdownMenuButton__text').innerHTML = certificationName;
 }
 
 function handleCertificationSelection(certification) {
     if (!certification) return;
     selectedCertification = certification;
-    const certificationCategories = certification.getCategories();
     hideMoreStats();
     let toolContentContainer = document.getElementById('tool__content-container');
     toolContentContainer.innerHTML = '';
-
-    for (let i = 0; i < certificationCategories.length; i++) {
-        const category = certificationCategories[i];
-
-        let htmlContent = '<div class="tool__content-box"><label for="category-' + i + '" id="categoryLabel-' + i + '" class="tool__content-category">' + category.name + '</label><input type="number" min=0 max=100 name="category-' + i + '" class="tool__content-categoryvalue" id="category-' + i + '" required></div>';
+    for (const key of certification.getCategories().keys()) {
+        const kebabKey = toKebabCase(key);
+        const htmlContent = `<div class="tool__content-box"><label for="category-${kebabKey}" id="category-${kebabKey}-label" class="tool__content-category">${key}</label><input type="number" min=0 max=100 name="${key}" class="tool__content-categoryvalue" id="category-${kebabKey}" required></div>`;
         toolContentContainer.insertAdjacentHTML('beforeend', htmlContent);
-    }
+    };
 }
 
 function showMoreStats() {
-    if (document.getElementById('categoryLabel-1').innerHTML.endsWith('%)')) {
-        resetCategoryLabels();
-    }
+    resetCategoryLabels();
     const categories = selectedCertification.getCategories();
     const inputs = document.getElementsByTagName('input');
     let moreStatsTag = document.getElementById('tool__content-moreStats-message');
     let bullet = '•';
     document.getElementById('tool__content-moreStats').classList.remove('hide');
     moreStatsTag.innerHTML = '';
-    let explenation = '<i class="far fa-info"></i> </br><i>Each <font color="#530040">•</font> represents the negative impact each category had on your result. The dots translates to how many percentages away you were from the maximum it could give. Keep on studying on the categories that have the most dots (negative impact), and you\'ll do even better in no time!</i>';
-    for (let i = 0; i < inputs.length; ++i) {
-        document.getElementById('categoryLabel-' + i).innerHTML += ' (' + Math.round(inputs[i].value * categories[i].weight) + '% / ' + Math.round(categories[i].weight * 100) + '%)';
-        moreStatsTag.innerHTML += '</br>' + categories[i].name + '</br><font color="#530040">' + bullet.repeat(Math.round(categories[i].weight * 100) - Math.round(inputs[i].value * categories[i].weight)) + '</font>';
+    for (const input of inputs) {
+        document.getElementById(`${input.id}-label`).innerHTML += ` (${Math.round(input.value * categories.get(input.name) * 0.01)}% / ${Math.round(categories.get(input.name))}%)`;
+        moreStatsTag.innerHTML += `</br>${input.name}</br><font color="#530040">${bullet.repeat(Math.round(categories.get(input.name)) - Math.round(input.value * categories.get(input.name) * 0.01))}</font>`;
     }
-    moreStatsTag.innerHTML += '</br></br></br>' + explenation;
+    moreStatsTag.innerHTML += '</br></br></br><i class="far fa-info"></i> </br><i>Each <font color="#530040">•</font> represents the negative impact each category had on your result. The dots translates to how many percentages away you were from the maximum it could give. Keep on studying on the categories that have the most dots (negative impact), and you\'ll do even better in no time!</i>';
     document.getElementById('moreStatsButton').classList.add('hide');
     
     return false;
@@ -411,9 +508,8 @@ function hideMoreStats() {
 
 function resetCategoryLabels() {
     const inputs = document.getElementsByTagName('input');
-    const categories = selectedCertification.getCategories();
-    for (let i = 0; i < inputs.length; ++i) {
-        document.getElementById('categoryLabel-' + i).innerHTML = categories[i].name;
+    for (const input of inputs) {
+        document.getElementById(input.id + '-label').innerHTML = input.name;
     }
 }
 
@@ -428,15 +524,12 @@ function handleCalculate() {
     const categories = selectedCertification.getCategories();
     const inputs = document.getElementsByTagName('input');
     for (let i = 0; i < inputs.length; ++i) {
-        finalScore += inputs[i].value * categories[i].weight;
+        finalScore += inputs[i].value * categories.get(inputs[i].name) * 0.01;
     }
-
 
     finalScore = Math.round(finalScore);
 
-
     const totalScoreDifference = Math.abs(finalScore - selectedCertification.passingScore);
-
 
     let message = document.getElementById('tool__content-total-message');
 
@@ -466,3 +559,10 @@ function handleCalculate() {
 
     return false;
 }
+
+const toKebabCase = str =>
+    str &&
+    str
+        .match(/[A-Z]{2,}(?=[A-Z][a-z]+[0-9]*|\b)|[A-Z]?[a-z]+[0-9]*|[A-Z]|[0-9]+/g)
+        .map(x => x.toLowerCase())
+        .join('-');


### PR DESCRIPTION
The more certifications are added, to more things there are to maintain. To make maintenance way easier, this PR:
- Collects all information about each certification in a single place, instead of 4
- Collects the Category information in a Map instead of two arrays, which makes it way easier to verify if all the categories have the right weight or not.
- Adds the Roles a certification relates to in the Certification object, instead of a separate Map which before had to be maintained separately.
- Automatically populates the Role- and Certification picklists on the canvas in JS. We no longer need to remember to add new certifications and roles to the index.html page.