### PR TITLE
Business Analyst certification pass rate update

### DIFF
--- a/resources/js/index.js
+++ b/resources/js/index.js
@@ -129,7 +129,7 @@ certificationMap.set('Pardot Specialist', new Certification('Pardot Specialist',
 ])));
 
 // //CONSULTANT
-certificationMap.set('Business Analyst', new Certification('Business Analyst', 60, 62, [ADMIN, CONSULTANT], new Map([
+certificationMap.set('Business Analyst', new Certification('Business Analyst', 60, 72, [ADMIN, CONSULTANT], new Map([
     ['Customer Discovery', 17],
     ['Collaboration with Stakeholders', 24],
     ['Business Process Mapping', 16],


### PR DESCRIPTION
The pass rate has updated to 72%

https://trailhead.salesforce.com/content/learn/modules/salesforce-business-analyst-certification-prep/get-started-with-salesforce-business-analyst-certification-prep

> Passing Score
> 72%


